### PR TITLE
Fix treesit-(beginning|end)-of-defun

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ settings or manually download anything additional.
   * Observe some syntax highlighting :)
   * `M-x imenu`
   * `M-x which-function-mode`
-  * `M-x treesit-end-of-defun` - might be a bit weird due to
-    [this](https://github.com/tree-sitter/tree-sitter-bash/issues/139)
+  * `M-x treesit-end-of-defun`
   * `M-x treesit-beginning-of-defun`
 
 * Developer-ish things:


### PR DESCRIPTION
This is an attempt to address #6.

I haven't tested it much yet, but I'll be trying it out.

Happy to have feedback from anyone who tries :)

---

[47ec9f4](https://github.com/sogaiu/janet-ts-mode/commit/47ec9f469eba938a8524bcf576606d0180d5240f) is an attempt to implement:

1. basic support for `treesit-(beginning|end)-of-defun`
2. "convenient navigation" as described [here](https://github.com/sogaiu/janet-ts-mode/issues/6#issuecomment-3105792408)
1. optional special handling of the content of `comment` forms as mentioned [here](https://github.com/sogaiu/janet-ts-mode/issues/6#issuecomment-3108443909)